### PR TITLE
Switched to isotope-layout lib reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 Views display plugin with [isotope](https://github.com/metafizzy/isotope) integration (drupal 8)
 
 ### Install required libraries
-Use bower in project root to install and isotope.
+Use Bower or Composer to install the required libraries.
 
-`bower install isotope --save`
+#### Using Bower
+Use bower in project root to install and isotope.
+```
+bower install isotope-layout --save
+```
+
+#### Using Composer
+Add npm as a respoitory in composer.json:
+```
+{
+  "repositories": {
+    "npm": {
+        "type": "composer",
+        "url": "https://asset-packagist.org"
+    }
+  }
+}
+```
+
+Require the isotope-layout library:
+```
+composer require npm-asset/isotope-layout:^3.0
+```

--- a/isotope_views.install
+++ b/isotope_views.install
@@ -9,20 +9,27 @@
  * Implements hook_requirements().
  */
 function isotope_views_requirements($phase) {
-
   $requirements = [];
 
-  $path = DRUPAL_ROOT . '/libraries/isotope/dist/isotope.pkgd.min.js';
-
-  if (!file_exists($path)) {
-    $requirements['isotope'] = array(
-      'title' => t('isotope library missing'),
-      'description' => t(
-        'Isotope_views requires the isotope library. Download https://github.com/metafizzy/isotope/releases/latest and extract it to /libraries/isotope.'
-      ),
-      'severity' => REQUIREMENT_ERROR,
-    );
+  if ($phase != 'runtime') {
+    return [];
   }
+
+  if (function_exists('libraries_get_path')) {
+    $path = libraries_get_path('isotope-layout') . '/dist/isotope.pkgd.min.js';
+  }
+  else {
+    $path = DRUPAL_ROOT . '/libraries/isotope-layout/dist/isotope.pkgd.min.js';
+  }
+
+  $exists = is_file($path);
+
+  $requirements['isotope-layout'] = [
+    'title'       => t('Isotope library'),
+    'description' => $exists ? '' : t('The <a href=":url">Isotope library</a> should be installed at <strong>/libraries/isotope-layout/dist/isotope.pkgd.min.js</strong>, or any path supported by libraries.module if installed.', [':url' => 'https://github.com/metafizzy/isotope']),
+    'severity'    => $exists ? REQUIREMENT_OK : REQUIREMENT_ERROR,
+    'value'       => $exists ? t('Installed') : t('Not installed'),
+  ];
 
   return $requirements;
 }

--- a/isotope_views.libraries.yml
+++ b/isotope_views.libraries.yml
@@ -1,7 +1,7 @@
-isotope:
+isotope_layout:
   version: 3.0.1
   js:
-    /libraries/isotope/dist/isotope.pkgd.min.js: {}
+    /libraries/isotope-layout/dist/isotope.pkgd.min.js: {}
   dependencies:
     - core/jquery
     - core/drupal
@@ -14,4 +14,4 @@ isotope_views:
   js:
     js/isotope_views.js: {}
   dependencies:
-    - isotope_views/isotope
+    - isotope_views/isotope_layout


### PR DESCRIPTION
The Isotope library is now being referred to as isotope-layout in asset repositories.